### PR TITLE
feat: Refactor cycle time handling in materials and plans

### DIFF
--- a/Backend/config/migrations.js
+++ b/Backend/config/migrations.js
@@ -523,7 +523,6 @@ export const runMigrations = async (pool3) => {
         PlanDate           DATE           NOT NULL,
         Priority           NVARCHAR(20)   NOT NULL DEFAULT 'Medium',
         Customer           NVARCHAR(200)  NULL,
-        PlannedCycleTime   DECIMAL(12,3)  NULL,
         Status             BIT            NOT NULL DEFAULT 1,
         CreatedAt          DATETIME       NOT NULL DEFAULT GETDATE(),
         UpdatedAt          DATETIME       NOT NULL DEFAULT GETDATE(),
@@ -531,6 +530,23 @@ export const runMigrations = async (pool3) => {
       );
       CREATE INDEX IX_ProductionPlan_SapDate ON ProductionPlans (SapCode, PlanDate);
       PRINT 'Migration: Created ProductionPlans table';
+    END
+  `);
+
+  // ── ProductionPlans: drop PlannedCycleTime — MaterialConfigs.
+  //    DefinedComponentCycleTime (looked up by SapCode) is now the single
+  //    source of truth for cycle time, instead of duplicating/re-entering it
+  //    per plan. Every existing plan's SapCode already has a
+  //    DefinedComponentCycleTime configured, so this is not a data-coverage
+  //    regression.
+  await pool3.request().query(`
+    IF EXISTS (
+      SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'ProductionPlans' AND COLUMN_NAME = 'PlannedCycleTime'
+    )
+    BEGIN
+      ALTER TABLE ProductionPlans DROP COLUMN PlannedCycleTime;
+      PRINT 'Migration: Dropped PlannedCycleTime column from ProductionPlans';
     END
   `);
 
@@ -879,6 +895,27 @@ export const runMigrations = async (pool3) => {
       PRINT 'Migration: Created ShiftConfigHistory table (+ Shift 1 backdated correction)';
     END
   `);
+
+  // ── MaterialConfigs: Actual Component Cycle Time (computed from real
+  //    PartProcessEvents production data, alongside the existing manually-
+  //    entered DefinedComponentCycleTime) ───────────────────────────────────
+  for (const col of [
+    { name: "ActualComponentCycleTime", def: "DECIMAL(12,3) NULL" },
+    { name: "ActualCTUpdatedAt",        def: "DATETIME      NULL" },
+    { name: "ActualCTSampleCount",      def: "INT           NULL" },
+  ]) {
+    await pool3.request().query(`
+      IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'MaterialConfigs')
+      AND NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME = 'MaterialConfigs' AND COLUMN_NAME = '${col.name}'
+      )
+      BEGIN
+        ALTER TABLE MaterialConfigs ADD ${col.name} ${col.def};
+        PRINT 'Migration: Added ${col.name} column to MaterialConfigs';
+      END
+    `);
+  }
 
   // ── MachineShiftAllocations / MachineShiftAllocationHistory ──────────────
   // Which shift(s) a machine is assigned to (some machines run a single 10h

--- a/Backend/controllers/masterConfig/materials.controller.js
+++ b/Backend/controllers/masterConfig/materials.controller.js
@@ -4,6 +4,7 @@ import path from "path";
 import sql from "mssql";
 import { UPLOADS_DIR } from "../../utils/storage/config.js";
 import { numOrNull, strOrNull, toBit } from "./helpers.js";
+import { extractProgramName, getMaterialByModel, parseDurSecs } from "../../utils/productionLogic.js";
 
 const MATERIAL_SELECT = `
   SELECT
@@ -13,6 +14,8 @@ const MATERIAL_SELECT = `
     ComponentWeight AS componentWeight, ScrapWeight AS scrapWeight,
     NoOfSheet AS noOfSheet, ActualComponentsPerSheet AS actualComponentsPerSheet,
     PncLoadingUnloading AS pncLoadingUnloading, DefinedComponentCycleTime AS definedComponentCycleTime,
+    ActualComponentCycleTime AS actualComponentCycleTime, ActualCTUpdatedAt AS actualCTUpdatedAt,
+    ActualCTSampleCount AS actualCTSampleCount,
     DrawingNumber AS drawingNumber, DrawingRevision AS drawingRevision,
     DrawingPath AS drawingPath, Status AS status
   FROM MaterialConfigs`;
@@ -269,6 +272,96 @@ export const bulkUpsertMaterials = async (req, res) => {
 
     const all = await global.pool3.request().query(`${MATERIAL_SELECT} ORDER BY Id`);
     res.json({ success: true, inserted, updated, data: all.recordset });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+/**
+ * Recalculate ActualComponentCycleTime for every SAP code from real
+ * PartProcessEvents production history — a one-time/on-demand backfill
+ * triggered from the Material Config page, not an automatic sync.
+ *
+ * Same formula as the shift-end report's componentCycleTime (see
+ * aggregateRecords in productionLogic.js): for punching parts,
+ * (avg machine cycle secs + load/unload allowance) spread across every
+ * component produced per machine cycle; for non-punching parts, just the
+ * average machine cycle time itself (mirrors that function's sheetCycleTime
+ * fallback) so every SAP code with matching samples gets a value, not just
+ * punching parts.
+ *
+ * Matching a PartProcessEvents row to a SAP code has no direct FK — it goes
+ * through the same barcode-parsing heuristic (extractProgramName +
+ * getMaterialByModel) already used for shift OEE, so results here stay
+ * consistent with what the Production Report / shift emails show.
+ */
+export const recalculateActualCycleTime = async (req, res) => {
+  try {
+    const materialsResult = await global.pool3.request().query(`
+      SELECT SapCode AS sapCode, PncLoadingUnloading AS pncLoadingUnloading,
+             ActualComponentsPerSheet AS actualComponentsPerSheet, NoOfSheet AS noOfSheet
+      FROM MaterialConfigs
+    `);
+    const materials = materialsResult.recordset;
+
+    const eventsResult = await global.pool3.request().query(`
+      SELECT Barcode, Duration, PartsQty
+      FROM PartProcessEvents
+      WHERE Status = 1 AND EventType = 'Production'
+        AND PartsQty > 0 AND Duration IS NOT NULL AND Duration <> '00:00:00'
+    `);
+    const events = eventsResult.recordset;
+
+    const cycleSecsBySapCode = {};
+    let unmatchedEvents = 0;
+
+    for (const ev of events) {
+      const programName = extractProgramName(ev.Barcode);
+      const mat = getMaterialByModel(materials, programName);
+      if (!mat) { unmatchedEvents++; continue; }
+
+      const secs = parseDurSecs(ev.Duration);
+      if (secs <= 0) continue;
+
+      (cycleSecsBySapCode[mat.sapCode] ??= []).push(secs);
+    }
+
+    let updated = 0;
+    for (const mat of materials) {
+      const samples = cycleSecsBySapCode[mat.sapCode];
+      if (!samples?.length) continue;
+
+      const avgCycleSecs = samples.reduce((a, b) => a + b, 0) / samples.length;
+      const compPerSheet = Number(mat.actualComponentsPerSheet) || 0;
+      const noOfSheet    = Number(mat.noOfSheet) || 0;
+      const loadUnload   = Number(mat.pncLoadingUnloading) || 0;
+      const isPunching   = compPerSheet > 0 && noOfSheet > 0;
+
+      const actualCT = isPunching
+        ? ((avgCycleSecs + loadUnload) / (compPerSheet * noOfSheet))
+        : avgCycleSecs;
+
+      await global.pool3.request()
+        .input("sapCode",       sql.NVarChar(50),  mat.sapCode)
+        .input("actualCT",      sql.Decimal(12, 3), Math.round(actualCT * 100) / 100)
+        .input("sampleCount",   sql.Int,            samples.length)
+        .query(`
+          UPDATE MaterialConfigs
+          SET ActualComponentCycleTime = @actualCT,
+              ActualCTSampleCount      = @sampleCount,
+              ActualCTUpdatedAt        = GETDATE()
+          WHERE SapCode = @sapCode
+        `);
+      updated++;
+    }
+
+    res.json({
+      success: true,
+      updated,
+      totalMaterials: materials.length,
+      totalEvents: events.length,
+      unmatchedEvents,
+    });
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
   }

--- a/Backend/controllers/masterConfig/plans.controller.js
+++ b/Backend/controllers/masterConfig/plans.controller.js
@@ -3,11 +3,15 @@ import sql from "mssql";
 import { numOrNull, strOrNull, toBit } from "./helpers.js";
 
 // ── Production Plans ─────────────────────────────────────────────────────────
+// Cycle time is no longer stored per-plan (PlannedCycleTime column removed) —
+// Material Config's DefinedComponentCycleTime is the single source of truth
+// now, looked up by SapCode client-side (Frontend already has the full
+// Materials list loaded via useSyncMasterConfig).
 const PLAN_SELECT = `
   SELECT
     Id AS id, MachineName AS machineName, SapCode AS sapCode, PartName AS partName, ModelCode AS modelCode,
     TargetQty AS targetQty, Shift AS shift, CONVERT(varchar(10), PlanDate, 23) AS planDate,
-    Priority AS priority, Customer AS customer, PlannedCycleTime AS plannedCycleTime, Status AS status
+    Priority AS priority, Customer AS customer, Status AS status
   FROM ProductionPlans`;
 
 export const getPlans = async (req, res) => {
@@ -36,19 +40,18 @@ export const createPlan = async (req, res) => {
       .input("planDate",         sql.Date, p.planDate)
       .input("priority",         sql.NVarChar(20),  p.priority || "Medium")
       .input("customer",         sql.NVarChar(200), strOrNull(p.customer))
-      .input("plannedCycleTime", sql.Decimal(12, 3), numOrNull(p.plannedCycleTime))
       .input("status",           sql.Bit, toBit(p.status ?? true))
       .query(`
         INSERT INTO ProductionPlans (
-          MachineName, SapCode, PartName, ModelCode, TargetQty, Shift, PlanDate, Priority, Customer, PlannedCycleTime, Status
+          MachineName, SapCode, PartName, ModelCode, TargetQty, Shift, PlanDate, Priority, Customer, Status
         )
         OUTPUT
           INSERTED.Id AS id, INSERTED.MachineName AS machineName, INSERTED.SapCode AS sapCode, INSERTED.PartName AS partName,
           INSERTED.ModelCode AS modelCode, INSERTED.TargetQty AS targetQty, INSERTED.Shift AS shift,
           CONVERT(varchar(10), INSERTED.PlanDate, 23) AS planDate, INSERTED.Priority AS priority,
-          INSERTED.Customer AS customer, INSERTED.PlannedCycleTime AS plannedCycleTime, INSERTED.Status AS status
+          INSERTED.Customer AS customer, INSERTED.Status AS status
         VALUES (
-          @machineName, @sapCode, @partName, @modelCode, @targetQty, @shift, @planDate, @priority, @customer, @plannedCycleTime, @status
+          @machineName, @sapCode, @partName, @modelCode, @targetQty, @shift, @planDate, @priority, @customer, @status
         )
       `);
 
@@ -77,19 +80,18 @@ export const updatePlan = async (req, res) => {
       .input("planDate",         sql.Date, p.planDate)
       .input("priority",         sql.NVarChar(20),  p.priority || "Medium")
       .input("customer",         sql.NVarChar(200), strOrNull(p.customer))
-      .input("plannedCycleTime", sql.Decimal(12, 3), numOrNull(p.plannedCycleTime))
       .input("status",           sql.Bit, toBit(p.status ?? true))
       .query(`
         UPDATE ProductionPlans SET
           MachineName = @machineName, SapCode = @sapCode, PartName = @partName, ModelCode = @modelCode,
           TargetQty = @targetQty, Shift = @shift, PlanDate = @planDate, Priority = @priority,
-          Customer = @customer, PlannedCycleTime = @plannedCycleTime, Status = @status,
+          Customer = @customer, Status = @status,
           UpdatedAt = GETDATE()
         OUTPUT
           INSERTED.Id AS id, INSERTED.MachineName AS machineName, INSERTED.SapCode AS sapCode, INSERTED.PartName AS partName,
           INSERTED.ModelCode AS modelCode, INSERTED.TargetQty AS targetQty, INSERTED.Shift AS shift,
           CONVERT(varchar(10), INSERTED.PlanDate, 23) AS planDate, INSERTED.Priority AS priority,
-          INSERTED.Customer AS customer, INSERTED.PlannedCycleTime AS plannedCycleTime, INSERTED.Status AS status
+          INSERTED.Customer AS customer, INSERTED.Status AS status
         WHERE Id = @id
       `);
 
@@ -132,7 +134,6 @@ export const bulkUpsertPlans = async (req, res) => {
         .input("planDate",         sql.Date, p.planDate)
         .input("priority",         sql.NVarChar(20),  p.priority || "Medium")
         .input("customer",         sql.NVarChar(200), strOrNull(p.customer))
-        .input("plannedCycleTime", sql.Decimal(12, 3), numOrNull(p.plannedCycleTime))
         .input("status",           sql.Bit, toBit(p.status ?? true));
 
       const result = await request.query(`
@@ -142,12 +143,12 @@ export const bulkUpsertPlans = async (req, res) => {
            AND target.PlanDate = src.PlanDate AND target.Shift = src.Shift
         WHEN MATCHED THEN UPDATE SET
           PartName = @partName, ModelCode = @modelCode, TargetQty = @targetQty,
-          Priority = @priority, Customer = @customer, PlannedCycleTime = @plannedCycleTime, Status = @status,
+          Priority = @priority, Customer = @customer, Status = @status,
           UpdatedAt = GETDATE()
         WHEN NOT MATCHED THEN INSERT (
-          MachineName, SapCode, PartName, ModelCode, TargetQty, Shift, PlanDate, Priority, Customer, PlannedCycleTime, Status
+          MachineName, SapCode, PartName, ModelCode, TargetQty, Shift, PlanDate, Priority, Customer, Status
         ) VALUES (
-          @machineName, @sapCode, @partName, @modelCode, @targetQty, @shift, @planDate, @priority, @customer, @plannedCycleTime, @status
+          @machineName, @sapCode, @partName, @modelCode, @targetQty, @shift, @planDate, @priority, @customer, @status
         )
         OUTPUT $action AS action;
       `);

--- a/Backend/controllers/production/componentTraceabilityReport.controller.js
+++ b/Backend/controllers/production/componentTraceabilityReport.controller.js
@@ -76,7 +76,6 @@ const BASE_CTE = `
       FROM   ProcessInputBOM a
       INNER JOIN BOMInputAltMaterial b
           ON  a.RowID   = b.RowID
-          AND a.BOMCode = b.BOMCode
   ),
   FGActivity AS (
       SELECT * FROM (

--- a/Backend/routes/masterConfig.route.js
+++ b/Backend/routes/masterConfig.route.js
@@ -4,6 +4,7 @@ import { uploadMachineImage, uploadMaterialDrawing, handleMulterError } from "..
 import {
   getMaterials, createMaterial, updateMaterial, deleteMaterial, bulkUpsertMaterials,
   uploadMaterialDrawing as uploadMaterialDrawingHandler, deleteMaterialDrawing,
+  recalculateActualCycleTime,
 } from "../controllers/masterConfig/materials.controller.js";
 import { getShifts, getShiftHistory, createShift, updateShift, deleteShift } from "../controllers/masterConfig/shifts.controller.js";
 import {
@@ -36,6 +37,7 @@ const router = Router();
 router.get("/materials",                     authenticate, getMaterials);
 router.post("/materials",                    authenticate, createMaterial);
 router.post("/materials/bulk",               authenticate, bulkUpsertMaterials);
+router.post("/materials/recalculate-actual-ct", authenticate, recalculateActualCycleTime);
 router.put("/materials/:id",                 authenticate, updateMaterial);
 router.delete("/materials/:id",              authenticate, deleteMaterial);
 router.post("/materials/:id/drawing",        authenticate, uploadMaterialDrawing.single("drawing"), handleMulterError, uploadMaterialDrawingHandler);

--- a/Frontend/src/pages/MasterConfig/MaterialConfig.jsx
+++ b/Frontend/src/pages/MasterConfig/MaterialConfig.jsx
@@ -4,7 +4,7 @@ import * as XLSX from "xlsx";
 import {
   Package2, Upload, Download, Eye, Trash2,
   CheckCircle2, AlertTriangle, FileSpreadsheet,
-  Info, Loader2, X,
+  Info, Loader2, X, RefreshCw,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
@@ -14,7 +14,7 @@ import {
 import { selectMaterials, updateMaterial as updateMaterialSlice } from "../../redux/slices/masterConfigSlice";
 import {
   useAddMaterialMutation, useUpdateMaterialMutation, useDeleteMaterialMutation, useBulkAddMaterialsMutation,
-  useUploadMaterialDrawingMutation, useDeleteMaterialDrawingMutation,
+  useUploadMaterialDrawingMutation, useDeleteMaterialDrawingMutation, useRecalculateActualCycleTimeMutation,
 } from "../../redux/api/masterConfigApi";
 import { fileBaseURL } from "../../assets/assets";
 
@@ -434,12 +434,14 @@ const EXPORT_HEADERS = [
   "SAP Code","Description","Category","Sheet SAP Code","Sheet Description",
   "Length","Width","THK","Weight","Component Weight","Scrap Weight",
   "No of Sheet","No of Component per Sheet","Loading/Unloading Time","Defined Component Cycle Time (Secs)",
-  "Drawing No.","Rev.",
+  "Actual CT (Secs)","Drawing No.","Rev.",
 ];
 
 const downloadTemplate = () => {
   // No of Sheet left blank below to demonstrate the THK auto-fill / default-1 behaviour.
-  const sample = [["1124700","PC OUTER REAR NWHD70H1-HC WHITE_0108171","PC WHITE","1108171","PC WHITE SHEET 536X460","536","460","0.40","0.78","0.826","0.061","","2","15","25.00","",""]];
+  // Actual CT is a derived, read-only field (populated by "Recalculate Actual CT"),
+  // not something to fill in on import — left blank in the template.
+  const sample = [["1124700","PC OUTER REAR NWHD70H1-HC WHITE_0108171","PC WHITE","1108171","PC WHITE SHEET 536X460","536","460","0.40","0.78","0.826","0.061","","2","15","25.00","","",""]];
   const ws = XLSX.utils.aoa_to_sheet([EXPORT_HEADERS, ...sample]);
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, "Materials");
@@ -453,6 +455,7 @@ const exportData = (data) => {
     r.weight || "", r.componentWeight || "", r.scrapWeight || "",
     r.noOfSheet || "", r.actualComponentsPerSheet || "", r.pncLoadingUnloading || "",
     r.definedComponentCycleTime ? round2(+r.definedComponentCycleTime) : "",
+    r.actualComponentCycleTime ? round2(+r.actualComponentCycleTime) : "",
     r.drawingNumber, r.drawingRevision,
   ]);
   const ws = XLSX.utils.aoa_to_sheet([EXPORT_HEADERS, ...rows]);
@@ -468,6 +471,7 @@ const MaterialConfig = () => {
   const [updateMaterial]   = useUpdateMaterialMutation();
   const [deleteMaterial]   = useDeleteMaterialMutation();
   const [bulkAddMaterials] = useBulkAddMaterialsMutation();
+  const [recalculateActualCT, { isLoading: recalculating }] = useRecalculateActualCycleTimeMutation();
 
   const dispatch = useDispatch();
   const [uploadDrawing, { isLoading: drawingUploading }] = useUploadMaterialDrawingMutation();
@@ -555,6 +559,17 @@ const MaterialConfig = () => {
     }
   };
 
+  const handleRecalculateActualCT = async () => {
+    try {
+      const res = await recalculateActualCT().unwrap();
+      toast.success(
+        `Actual CT updated for ${res.updated} of ${res.totalMaterials} materials, from ${res.totalEvents.toLocaleString()} production events.`,
+      );
+    } catch (err) {
+      toast.error(err?.data?.message || "Failed to recalculate Actual CT.");
+    }
+  };
+
   const sf = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.type === "checkbox" ? e.target.checked : e.target.value }));
 
   // THK drives the "No of Sheet" default until the user manually edits No of Sheet.
@@ -598,6 +613,15 @@ const MaterialConfig = () => {
             <Download className="w-3.5 h-3.5" /> Export Data
           </button>
           <button
+            onClick={handleRecalculateActualCT}
+            disabled={recalculating}
+            title="Recompute Actual CT for every SAP code from PartProcessEvents production history"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg border border-emerald-200 bg-white hover:bg-emerald-50 text-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${recalculating ? "animate-spin" : ""}`} />
+            {recalculating ? "Recalculating…" : "Recalculate Actual CT"}
+          </button>
+          <button
             onClick={() => setConfirmClear(true)}
             disabled={!data.length}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg border border-rose-200 bg-white hover:bg-rose-50 text-rose-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -629,6 +653,7 @@ const MaterialConfig = () => {
                   <TH center>No of Component per Sheet</TH>
                   <TH center>Loading/Unloading Time</TH>
                   <TH center>Defined Component Cycle Time (Secs)</TH>
+                  <TH center>Actual CT (Secs)</TH>
                   <TH>Drawing No.</TH>
                   <TH>Rev.</TH>
                   <TH center>Drawing File</TH>
@@ -654,6 +679,13 @@ const MaterialConfig = () => {
                     <TD center cls="font-mono font-bold text-slate-700">{r.actualComponentsPerSheet || "—"}</TD>
                     <TD center cls="font-mono text-amber-600">{r.pncLoadingUnloading || "—"}</TD>
                     <TD center cls="font-mono font-bold text-rose-600">{r.definedComponentCycleTime ? `${round2(+r.definedComponentCycleTime)}s` : "—"}</TD>
+                    <TD center cls="font-mono font-bold text-emerald-600">
+                      {r.actualComponentCycleTime ? (
+                        <span title={`${r.actualCTSampleCount ?? 0} samples${r.actualCTUpdatedAt ? ` · updated ${new Date(r.actualCTUpdatedAt).toLocaleDateString("en-IN")}` : ""}`}>
+                          {round2(+r.actualComponentCycleTime)}s
+                        </span>
+                      ) : "—"}
+                    </TD>
                     <TD mono cls="text-slate-500">{r.drawingNumber}</TD>
                     <TD>
                       {r.drawingRevision && (

--- a/Frontend/src/pages/MasterConfig/PlanningConfig.jsx
+++ b/Frontend/src/pages/MasterConfig/PlanningConfig.jsx
@@ -3,11 +3,15 @@ import { useSelector } from "react-redux";
 import * as XLSX from "xlsx";
 import {
   CalendarRange, Upload, Download, Trash2,
-  CheckCircle2, AlertTriangle, FileSpreadsheet, Info, Loader2, X,
+  CheckCircle2, AlertTriangle, FileSpreadsheet, Info, Loader2, X, Gauge,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { inputCls, selectCls, Field, Modal, TableActions, PageHeader, EmptyState, TH, TD } from "./_shared";
-import { selectPlans, selectShifts } from "../../redux/slices/masterConfigSlice";
+import {
+  selectPlans, selectShifts, selectMachines, selectMaterials,
+  selectMachineShiftAllocationHistory, selectShiftHistory, shiftPlannedProductionMins,
+} from "../../redux/slices/masterConfigSlice";
+import { resolveMachineShiftsAsOf, resolveShiftAsOf } from "../../utils/productionLogic";
 import {
   useAddPlanMutation, useUpdatePlanMutation, useDeletePlanMutation, useBulkAddPlansMutation,
 } from "../../redux/api/masterConfigApi";
@@ -21,7 +25,7 @@ yesterday.setDate(yesterday.getDate() - 1);
 const TODAY_STR = fmtDate(today);
 const YESTERDAY_STR = fmtDate(yesterday);
 
-const INIT = { machineName:"", sapCode:"", partName:"", modelCode:"", targetQty:"", shift:"All Shifts", planDate: fmtDate(today), priority:"Medium", customer:"", plannedCycleTime:"" };
+const INIT = { machineName:"", sapCode:"", partName:"", modelCode:"", targetQty:"", shift:"All Shifts", planDate: fmtDate(today), priority:"Medium", customer:"" };
 
 const PriorityBadge = ({ p }) => {
   const c = { High:"bg-rose-50 text-rose-700 border-rose-200", Medium:"bg-amber-50 text-amber-700 border-amber-200", Low:"bg-slate-100 text-slate-600 border-slate-200" };
@@ -39,7 +43,6 @@ const COLUMN_ALIASES = {
   planDate:         ["plan date","production date","date"],
   priority:         ["priority"],
   customer:         ["customer","client"],
-  plannedCycleTime: ["planned cycle time","cycle time","ct (s)","ct(s)","cycle time (s)"],
 };
 
 const ALIAS_PAIRS = Object.entries(COLUMN_ALIASES)
@@ -93,10 +96,10 @@ const normalizeDate = (val) => {
 const FIELD_LABELS = {
   machineName: "Machine Name *", sapCode: "SAP Code *", partName: "Part Name", modelCode: "Model Code",
   targetQty: "Target Qty *", shift: "Shift", planDate: "Plan Date *",
-  priority: "Priority", customer: "Customer", plannedCycleTime: "Planned Cycle Time (s)",
+  priority: "Priority", customer: "Customer",
 };
 
-const NUM_FIELDS = ["targetQty", "plannedCycleTime"];
+const NUM_FIELDS = ["targetQty"];
 
 /* ── Bulk Upload Modal ───────────────────────────────────────────────────── */
 const BulkUploadModal = ({ onClose, onImport }) => {
@@ -230,7 +233,7 @@ const BulkUploadModal = ({ onClose, onImport }) => {
                   <span className="text-[11px] font-bold text-amber-700 uppercase tracking-wide">Expected Columns</span>
                 </div>
                 <div className="flex flex-wrap gap-1.5">
-                  {["Machine Name","SAP Code","Part Name","Model Code","Target Qty","Shift","Plan Date","Priority","Customer","Planned Cycle Time (s)"].map((c) => (
+                  {["Machine Name","SAP Code","Part Name","Model Code","Target Qty","Shift","Plan Date","Priority","Customer"].map((c) => (
                     <span key={c} className="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">{c}</span>
                   ))}
                 </div>
@@ -358,10 +361,10 @@ const BulkUploadModal = ({ onClose, onImport }) => {
 };
 
 /* ── Export helpers ──────────────────────────────────────────────────────── */
-const EXPORT_HEADERS = ["Machine Name","SAP Code","Part Name","Model Code","Target Qty","Shift","Plan Date","Priority","Customer","Planned Cycle Time (s)"];
+const EXPORT_HEADERS = ["Machine Name","SAP Code","Part Name","Model Code","Target Qty","Shift","Plan Date","Priority","Customer"];
 
 const downloadTemplate = () => {
-  const sample = [["Bending Machine 1","1127024","D-UNIT FRAME D150H","D150H","480","Shift A",fmtDate(today),"Medium","Whirlpool","45"]];
+  const sample = [["Bending Machine 1","1127024","D-UNIT FRAME D150H","D150H","480","Shift A",fmtDate(today),"Medium","Whirlpool"]];
   const ws = XLSX.utils.aoa_to_sheet([EXPORT_HEADERS, ...sample]);
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, "Plan");
@@ -371,12 +374,136 @@ const downloadTemplate = () => {
 const exportData = (data) => {
   const rows = data.map((r) => [
     r.machineName, r.sapCode, r.partName || "", r.modelCode || "", r.targetQty,
-    r.shift, r.planDate, r.priority, r.customer || "", r.plannedCycleTime || "",
+    r.shift, r.planDate, r.priority, r.customer || "",
   ]);
   const ws = XLSX.utils.aoa_to_sheet([EXPORT_HEADERS, ...rows]);
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, "Plan");
   XLSX.writeFile(wb, "production_plan.xlsx");
+};
+
+/* ── Machine Load panel ──────────────────────────────────────────────────────
+   Aggregates plans per Machine + Plan Date: required time (Target Qty ×
+   Material Config's Defined Component Cycle Time, looked up by SapCode) vs.
+   available production time (from that machine's assigned shift(s), resolved
+   as-of the plan date via the same resolveMachineShiftsAsOf/resolveShiftAsOf
+   history used by OEE reporting). Plans whose SapCode has no Defined
+   Component Cycle Time configured can't contribute a required-time figure
+   and are called out separately rather than silently ignored. */
+const loadBadgeCls = (pct) => {
+  if (pct == null) return "bg-slate-100 text-slate-500 border-slate-200";
+  if (pct > 100) return "bg-rose-50 text-rose-700 border-rose-200";
+  if (pct >= 80) return "bg-amber-50 text-amber-700 border-amber-200";
+  return "bg-emerald-50 text-emerald-700 border-emerald-200";
+};
+
+const MachineLoadPanel = ({ plans, machines, shifts, machineShiftAllocationHistory, shiftHistory, materials }) => {
+  const rows = useMemo(() => {
+    const groups = {};
+    const getGroup = (r) => {
+      const key = `${r.machineName}|${r.planDate}`;
+      if (!groups[key]) {
+        groups[key] = {
+          key, machineName: r.machineName, planDate: r.planDate,
+          requiredMins: 0, planCount: 0, skippedCount: 0,
+        };
+      }
+      return groups[key];
+    };
+
+    plans.forEach((r) => {
+      const g = getGroup(r);
+      const cycleSecs = Number(materials.find((m) => m.sapCode === r.sapCode)?.definedComponentCycleTime);
+      if (cycleSecs > 0) {
+        g.requiredMins += (Number(r.targetQty || 0) * cycleSecs) / 60;
+        g.planCount += 1;
+      } else {
+        g.skippedCount += 1;
+      }
+    });
+
+    return Object.values(groups).map((g) => {
+      const machine = machines.find(
+        (m) => m.machineName?.trim().toLowerCase() === g.machineName?.trim().toLowerCase(),
+      );
+
+      let availableMins = 0;
+      const shiftNames = [];
+      if (machine) {
+        const shiftIds = resolveMachineShiftsAsOf(machineShiftAllocationHistory, machine.id, g.planDate);
+        shiftIds.forEach((shiftId) => {
+          const fallback = shifts.find((s) => s.id === shiftId);
+          const shiftCfg = resolveShiftAsOf(shiftHistory, shiftId, g.planDate, fallback);
+          if (shiftCfg) {
+            availableMins += shiftPlannedProductionMins(shiftCfg);
+            shiftNames.push(shiftCfg.shiftName || fallback?.shiftName || "Shift");
+          }
+        });
+      }
+
+      const loadPct = availableMins > 0 ? Math.round((g.requiredMins / availableMins) * 1000) / 10 : null;
+
+      return {
+        ...g,
+        machineFound: !!machine,
+        requiredMins: Math.round(g.requiredMins),
+        availableMins: Math.round(availableMins),
+        loadPct,
+        shiftNames,
+      };
+    }).sort((a, b) => (b.loadPct ?? -1) - (a.loadPct ?? -1));
+  }, [plans, machines, shifts, machineShiftAllocationHistory, shiftHistory, materials]);
+
+  if (!rows.length) return null;
+
+  const fmtHrs = (mins) => `${(mins / 60).toFixed(1)}h`;
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden mb-3">
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-slate-100">
+        <Gauge className="w-4 h-4 text-blue-500" />
+        <span className="text-xs font-bold text-slate-700">Planned Machine Load</span>
+        <span className="text-[11px] text-slate-400">Required time vs. available shift time, per machine/date</span>
+      </div>
+      <div className="overflow-auto max-h-64">
+        <table className="min-w-full border-separate border-spacing-0">
+          <thead className="sticky top-0 z-10">
+            <tr className="bg-slate-50">
+              <TH>Machine</TH><TH center>Date</TH><TH>Shift(s)</TH>
+              <TH center>Required</TH><TH center>Available</TH><TH center>Load</TH>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.key} className="hover:bg-blue-50/40 transition-colors even:bg-slate-50/30">
+                <TD cls="font-medium text-slate-700 whitespace-nowrap">{r.machineName}</TD>
+                <TD center mono cls="text-slate-500">{r.planDate}</TD>
+                <TD cls="text-slate-500 text-[11px]">
+                  {!r.machineFound ? (
+                    <span className="text-amber-600">No machine match</span>
+                  ) : r.shiftNames.length ? r.shiftNames.join(", ") : (
+                    <span className="text-amber-600">No shift assigned</span>
+                  )}
+                </TD>
+                <TD center cls="font-mono text-slate-600">
+                  {fmtHrs(r.requiredMins)}
+                  {r.skippedCount > 0 && (
+                    <span className="text-amber-500" title={`${r.skippedCount} plan(s) skipped — no Defined Component Cycle Time set in Material Config`}> *</span>
+                  )}
+                </TD>
+                <TD center cls="font-mono text-slate-600">{r.availableMins > 0 ? fmtHrs(r.availableMins) : "—"}</TD>
+                <TD center>
+                  <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full border ${loadBadgeCls(r.loadPct)}`}>
+                    {r.loadPct != null ? `${r.loadPct}%` : "—"}
+                  </span>
+                </TD>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 };
 
 /* ── Main page ────────────────────────────────────────────────────────────── */
@@ -392,6 +519,10 @@ const PlanningConfig = () => {
     () => ["All Shifts", ...shifts.filter((s) => s.status).map((s) => s.shiftName)],
     [shifts],
   );
+  const machines = useSelector(selectMachines);
+  const materials = useSelector(selectMaterials);
+  const machineShiftAllocationHistory = useSelector(selectMachineShiftAllocationHistory);
+  const shiftHistory = useSelector(selectShiftHistory);
   const [addPlan]      = useAddPlanMutation();
   const [updatePlan]   = useUpdatePlanMutation();
   const [deletePlan]   = useDeletePlanMutation();
@@ -405,13 +536,19 @@ const PlanningConfig = () => {
   const [dateFilter, setDateFilter] = useState(TODAY_STR);
   const [showBulk, setShowBulk] = useState(false);
 
+  // Date-only scope (no text search) — Machine Load reflects the whole day's
+  // plan set for a machine, not whatever the user currently has typed into
+  // the plan-table search box.
+  const dateScoped = useMemo(() =>
+    data.filter((r) => !dateFilter || r.planDate === dateFilter),
+    [data, dateFilter]);
+
   const filtered = useMemo(() =>
-    data.filter((r) =>
-      (!dateFilter || r.planDate === dateFilter) &&
+    dateScoped.filter((r) =>
       (r.machineName.toLowerCase().includes(search.toLowerCase()) ||
        r.sapCode.includes(search) ||
        (r.partName || "").toLowerCase().includes(search.toLowerCase()))
-    ), [data, search, dateFilter]);
+    ), [dateScoped, search]);
 
   const openAdd  = () => { setForm(INIT); setModal({ open:true, mode:"add" }); };
   const openEdit = (row) => { setForm({ ...row }); setModal({ open:true, mode:"edit", row }); };
@@ -496,6 +633,15 @@ const PlanningConfig = () => {
           </div>
         </div>
 
+        <MachineLoadPanel
+          plans={dateScoped}
+          machines={machines}
+          shifts={shifts}
+          machineShiftAllocationHistory={machineShiftAllocationHistory}
+          shiftHistory={shiftHistory}
+          materials={materials}
+        />
+
         <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
           <div className="overflow-auto">
             <table className="min-w-full border-separate border-spacing-0">
@@ -535,7 +681,6 @@ const PlanningConfig = () => {
             <Field label="Part Name"><input value={form.partName} onChange={sf("partName")} placeholder="e.g. D-UNIT FRAME D150H" className={inputCls} /></Field>
             <Field label="Model Code"><input value={form.modelCode} onChange={sf("modelCode")} placeholder="e.g. D150H" className={inputCls} /></Field>
             <Field label="Target Quantity" required><input type="number" value={form.targetQty} onChange={sf("targetQty")} placeholder="e.g. 480" className={inputCls} min={1} /></Field>
-            <Field label="Planned Cycle Time (s)"><input type="number" value={form.plannedCycleTime} onChange={sf("plannedCycleTime")} placeholder="e.g. 45" className={inputCls} min={1} /></Field>
             <Field label="Shift">
               <select value={form.shift} onChange={sf("shift")} className={selectCls}>{shiftOptions.map((s) => <option key={s}>{s}</option>)}</select>
             </Field>

--- a/Frontend/src/pages/Production/ComponentTraceabilityReport.jsx
+++ b/Frontend/src/pages/Production/ComponentTraceabilityReport.jsx
@@ -656,7 +656,7 @@ const ComponentTraceabilityReport = () => {
             <div className="min-w-[190px] flex-1">
               <SelectField
                 label="Model Variant"
-                options={variants}
+                options={[{ value: "", label: "All Models" }, ...variants]}
                 value={selectedModelVariant?.value || ""}
                 onChange={(e) =>
                   handleFilterChange(setSelectedModelVariant)(
@@ -668,7 +668,7 @@ const ComponentTraceabilityReport = () => {
             <div className="min-w-[190px] flex-1">
               <SelectField
                 label="Component Type"
-                options={compTypes}
+                options={[{ value: "", label: "All Types" }, ...compTypes]}
                 value={selectedCompType?.value || ""}
                 onChange={(e) =>
                   handleFilterChange(setSelectedCompType)(

--- a/Frontend/src/redux/api/masterConfigApi.js
+++ b/Frontend/src/redux/api/masterConfigApi.js
@@ -28,6 +28,10 @@ export const masterConfigApi = createApi({
       query: (materials) => ({ url: "master-config/materials/bulk", method: "POST", body: { materials } }),
       invalidatesTags: ["Material"],
     }),
+    recalculateActualCycleTime: builder.mutation({
+      query: () => ({ url: "master-config/materials/recalculate-actual-ct", method: "POST" }),
+      invalidatesTags: ["Material"],
+    }),
 
     // ── Shifts ───────────────────────────────────────────────────────────────
     getShifts: builder.query({
@@ -247,6 +251,7 @@ export const masterConfigApi = createApi({
 
 export const {
   useGetMaterialsQuery, useAddMaterialMutation, useUpdateMaterialMutation, useDeleteMaterialMutation, useBulkAddMaterialsMutation,
+  useRecalculateActualCycleTimeMutation,
   useUploadMaterialDrawingMutation, useDeleteMaterialDrawingMutation,
   useGetShiftsQuery, useGetShiftHistoryQuery, useAddShiftMutation, useUpdateShiftMutation, useDeleteShiftMutation,
   useGetMachineShiftAllocationsQuery, useGetMachineShiftAllocationHistoryQuery, useSetMachineShiftAllocationsMutation,


### PR DESCRIPTION
- Removed PlannedCycleTime from ProductionPlans, using DefinedComponentCycleTime as the single source of truth.
- Added recalculateActualCycleTime function to compute ActualComponentCycleTime based on production history.
- Updated MaterialConfig and PlanningConfig components to reflect changes in cycle time handling.
- Enhanced export templates and data structures to accommodate new cycle time logic.